### PR TITLE
Refactor game logic into reusable module

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -1,0 +1,191 @@
+import random
+from typing import Dict, List, Tuple
+
+# Grid dimensions
+GRID_WIDTH = 10
+GRID_HEIGHT = 20
+
+# Shapes represented in a 5x5 grid
+S = [['.....',
+      '.....',
+      '..00.',
+      '.00..',
+      '.....'],
+     ['.....',
+      '..0..',
+      '..00.',
+      '...0.',
+      '.....']]
+
+Z = [['.....',
+      '.....',
+      '.00..',
+      '..00.',
+      '.....'],
+     ['.....',
+      '..0..',
+      '.00..',
+      '.0...',
+      '.....']]
+
+I = [['..0..',
+      '..0..',
+      '..0..',
+      '..0..',
+      '.....'],
+     ['.....',
+      '0000.',
+      '.....',
+      '.....',
+      '.....']]
+
+O = [['.....',
+      '.....',
+      '.00..',
+      '.00..',
+      '.....']]
+
+J = [['.....',
+      '.0...',
+      '.000.',
+      '.....',
+      '.....'],
+     ['.....',
+      '..00.',
+      '..0..',
+      '..0..',
+      '.....'],
+     ['.....',
+      '.....',
+      '.000.',
+      '...0.',
+      '.....'],
+     ['.....',
+      '..0..',
+      '..0..',
+      '.00..',
+      '.....']]
+
+L = [['.....',
+      '...0.',
+      '.000.',
+      '.....',
+      '.....'],
+     ['.....',
+      '..0..',
+      '..0..',
+      '..00.',
+      '.....'],
+     ['.....',
+      '.....',
+      '.000.',
+      '.0...',
+      '.....'],
+     ['.....',
+      '.00..',
+      '..0..',
+      '..0..',
+      '.....']]
+
+T = [['.....',
+      '..0..',
+      '.000.',
+      '.....',
+      '.....'],
+     ['.....',
+      '..0..',
+      '..00.',
+      '..0..',
+      '.....'],
+     ['.....',
+      '.....',
+      '.000.',
+      '..0..',
+      '.....'],
+     ['.....',
+      '..0..',
+      '.00..',
+      '..0..',
+      '.....']]
+
+SHAPES = [S, Z, I, O, J, L, T]
+SHAPE_COLORS = [(0, 255, 0), (255, 0, 0), (0, 255, 255),
+                (255, 255, 0), (255, 165, 0), (0, 0, 255),
+                (128, 0, 128)]
+
+
+class Piece:
+    def __init__(self, x: int, y: int, shape: List[List[str]]):
+        self.x = x
+        self.y = y
+        self.shape = shape
+        self.color = SHAPE_COLORS[SHAPES.index(shape)]
+        self.rotation = 0
+
+
+def create_grid(locked_positions: Dict[Tuple[int, int], Tuple[int, int, int]]) -> List[List[Tuple[int, int, int]]]:
+    grid = [[(0, 0, 0) for _ in range(GRID_WIDTH)] for _ in range(GRID_HEIGHT)]
+    for (x, y), color in locked_positions.items():
+        grid[y][x] = color
+    return grid
+
+
+def convert_shape_format(piece: Piece) -> List[Tuple[int, int]]:
+    positions = []
+    format = piece.shape[piece.rotation % len(piece.shape)]
+    for i, line in enumerate(format):
+        for j, char in enumerate(line):
+            if char == '0':
+                positions.append((piece.x + j - 2, piece.y + i - 4))
+    return positions
+
+
+def valid_space(piece: Piece, grid: List[List[Tuple[int, int, int]]]) -> bool:
+    accepted_positions = [(j, i) for i in range(GRID_HEIGHT) for j in range(GRID_WIDTH) if grid[i][j] == (0, 0, 0)]
+    formatted = convert_shape_format(piece)
+    return all(pos in accepted_positions and pos[1] > -1 for pos in formatted)
+
+
+def move_piece(piece: Piece, dx: int, dy: int, grid: List[List[Tuple[int, int, int]]]) -> bool:
+    piece.x += dx
+    piece.y += dy
+    if not valid_space(piece, grid):
+        piece.x -= dx
+        piece.y -= dy
+        return False
+    return True
+
+
+def rotate_piece(piece: Piece, grid: List[List[Tuple[int, int, int]]]) -> bool:
+    piece.rotation += 1
+    if not valid_space(piece, grid):
+        piece.rotation -= 1
+        return False
+    return True
+
+
+def check_lost(positions: Dict[Tuple[int, int], Tuple[int, int, int]]) -> bool:
+    return any(y < 1 for (_, y) in positions)
+
+
+def get_shape() -> Piece:
+    return Piece(5, 0, random.choice(SHAPES))
+
+
+def clear_rows(grid: List[List[Tuple[int, int, int]]], locked: Dict[Tuple[int, int], Tuple[int, int, int]]) -> int:
+    rows_to_clear = [i for i in range(len(grid) - 1, -1, -1) if (0, 0, 0) not in grid[i]]
+    for row in rows_to_clear:
+        for j in range(len(grid[row])):
+            locked.pop((j, row), None)
+        for key in sorted(list(locked), key=lambda x: x[1])[::-1]:
+            x, y = key
+            if y < row:
+                locked[(x, y + 1)] = locked.pop(key)
+    return len(rows_to_clear)
+
+
+def lock_piece(piece: Piece, locked_positions: Dict[Tuple[int, int], Tuple[int, int, int]]) -> int:
+    for pos in convert_shape_format(piece):
+        locked_positions[(pos[0], pos[1])] = piece.color
+    grid = create_grid(locked_positions)
+    return clear_rows(grid, locked_positions) * 10

--- a/tests/test_game_logic.py
+++ b/tests/test_game_logic.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from game_logic import (
+    O,
+    SHAPES,
+    Piece,
+    check_lost,
+    create_grid,
+    lock_piece,
+    move_piece,
+)
+
+
+def test_move_piece_bounds():
+    grid = create_grid({})
+    piece = Piece(5, 2, SHAPES[0])
+    assert move_piece(piece, -1, 0, grid)
+    assert piece.x == 4
+    assert not move_piece(piece, -5, 0, grid)
+    assert piece.x == 4
+
+
+def test_lock_piece_and_score():
+    locked = {(i, 19): (255, 255, 255) for i in range(2, 10)}
+    piece = Piece(1, 20, O)
+    score = lock_piece(piece, locked)
+    assert score == 10
+    grid = create_grid(locked)
+    assert sum(1 for cell in grid[19] if cell != (0, 0, 0)) == 2
+    assert all((0, 0, 0) in row for row in grid)
+
+
+def test_check_lost():
+    locked = {(0, 0): (255, 255, 255)}
+    assert check_lost(locked)

--- a/tetris.py
+++ b/tetris.py
@@ -1,5 +1,4 @@
 import pygame
-import random
 from typing import List, Tuple
 
 # Initialize pygame's font module
@@ -15,152 +14,9 @@ BLOCK_SIZE = 30
 TOP_LEFT_X = (S_WIDTH - PLAY_WIDTH) // 2
 TOP_LEFT_Y = S_HEIGHT - PLAY_HEIGHT - 50
 
-# Shapes represented in a 5x5 grid
-S = [['.....',
-      '.....',
-      '..00.',
-      '.00..',
-      '.....'],
-     ['.....',
-      '..0..',
-      '..00.',
-      '...0.',
-      '.....']]
-
-Z = [['.....',
-      '.....',
-      '.00..',
-      '..00.',
-      '.....'],
-     ['.....',
-      '..0..',
-      '.00..',
-      '.0...',
-      '.....']]
-
-I = [['..0..',
-      '..0..',
-      '..0..',
-      '..0..',
-      '.....'],
-     ['.....',
-      '0000.',
-      '.....',
-      '.....',
-      '.....']]
-
-O = [['.....',
-      '.....',
-      '.00..',
-      '.00..',
-      '.....']]
-
-J = [['.....',
-      '.0...',
-      '.000.',
-      '.....',
-      '.....'],
-     ['.....',
-      '..00.',
-      '..0..',
-      '..0..',
-      '.....'],
-     ['.....',
-      '.....',
-      '.000.',
-      '...0.',
-      '.....'],
-     ['.....',
-      '..0..',
-      '..0..',
-      '.00..',
-      '.....']]
-
-L = [['.....',
-      '...0.',
-      '.000.',
-      '.....',
-      '.....'],
-     ['.....',
-      '..0..',
-      '..0..',
-      '..00.',
-      '.....'],
-     ['.....',
-      '.....',
-      '.000.',
-      '.0...',
-      '.....'],
-     ['.....',
-      '.00..',
-      '..0..',
-      '..0..',
-      '.....']]
-
-T = [['.....',
-      '..0..',
-      '.000.',
-      '.....',
-      '.....'],
-     ['.....',
-      '..0..',
-      '..00.',
-      '..0..',
-      '.....'],
-     ['.....',
-      '.....',
-      '.000.',
-      '..0..',
-      '.....'],
-     ['.....',
-      '..0..',
-      '.00..',
-      '..0..',
-      '.....']]
-
-SHAPES = [S, Z, I, O, J, L, T]
-SHAPE_COLORS = [(0, 255, 0), (255, 0, 0), (0, 255, 255),
-                (255, 255, 0), (255, 165, 0), (0, 0, 255),
-                (128, 0, 128)]
-
-class Piece:
-    def __init__(self, x: int, y: int, shape: List[List[str]]):
-        self.x = x
-        self.y = y
-        self.shape = shape
-        self.color = SHAPE_COLORS[SHAPES.index(shape)]
-        self.rotation = 0
-
-
-def create_grid(locked_positions: dict) -> List[List[Tuple[int, int, int]]]:
-    grid = [[(0, 0, 0) for _ in range(10)] for _ in range(20)]
-    for (j, i), color in locked_positions.items():
-        grid[i][j] = color
-    return grid
-
-
-def convert_shape_format(piece: Piece) -> List[Tuple[int, int]]:
-    positions = []
-    format = piece.shape[piece.rotation % len(piece.shape)]
-    for i, line in enumerate(format):
-        for j, char in enumerate(line):
-            if char == '0':
-                positions.append((piece.x + j - 2, piece.y + i - 4))
-    return positions
-
-
-def valid_space(piece: Piece, grid: List[List[Tuple[int, int, int]]]) -> bool:
-    accepted_positions = [(j, i) for i in range(20) for j in range(10) if grid[i][j] == (0, 0, 0)]
-    formatted = convert_shape_format(piece)
-    return all(pos in accepted_positions and pos[1] > -1 for pos in formatted)
-
-
-def check_lost(positions: dict) -> bool:
-    return any(y < 1 for (_, y) in positions)
-
-
-def get_shape() -> Piece:
-    return Piece(5, 0, random.choice(SHAPES))
+from game_logic import (check_lost, convert_shape_format, create_grid,
+                        get_shape, lock_piece, move_piece,
+                        rotate_piece)
 
 
 def draw_text_middle(surface, text, size, color):
@@ -177,22 +33,6 @@ def draw_grid(surface, grid):
         for j in range(len(grid[i])):
             pygame.draw.line(surface, (128, 128, 128), (TOP_LEFT_X + j * BLOCK_SIZE, TOP_LEFT_Y),
                              (TOP_LEFT_X + j * BLOCK_SIZE, TOP_LEFT_Y + PLAY_HEIGHT))
-
-
-def clear_rows(grid, locked):
-    rows_to_clear = [i for i in range(len(grid) - 1, -1, -1) if (0, 0, 0) not in grid[i]]
-    for row in rows_to_clear:
-        del_row = row
-        for j in range(len(grid[row])):
-            try:
-                del locked[(j, row)]
-            except KeyError:
-                pass
-        for key in sorted(list(locked), key=lambda x: x[1])[::-1]:
-            x, y = key
-            if y < del_row:
-                locked[(x, y + 1)] = locked.pop(key)
-    return len(rows_to_clear)
 
 
 def draw_next_shape(shape, surface):
@@ -253,9 +93,7 @@ def main():
                 fall_speed -= 0.005
         if fall_time / 1000 > fall_speed:
             fall_time = 0
-            current_piece.y += 1
-            if not valid_space(current_piece, grid) and current_piece.y > 0:
-                current_piece.y -= 1
+            if not move_piece(current_piece, 0, 1, grid):
                 change_piece = True
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
@@ -264,33 +102,22 @@ def main():
                 return
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_LEFT:
-                    current_piece.x -= 1
-                    if not valid_space(current_piece, grid):
-                        current_piece.x += 1
+                    move_piece(current_piece, -1, 0, grid)
                 elif event.key == pygame.K_RIGHT:
-                    current_piece.x += 1
-                    if not valid_space(current_piece, grid):
-                        current_piece.x -= 1
+                    move_piece(current_piece, 1, 0, grid)
                 elif event.key == pygame.K_DOWN:
-                    current_piece.y += 1
-                    if not valid_space(current_piece, grid):
-                        current_piece.y -= 1
+                    move_piece(current_piece, 0, 1, grid)
                 elif event.key == pygame.K_UP:
-                    current_piece.rotation += 1
-                    if not valid_space(current_piece, grid):
-                        current_piece.rotation -= 1
+                    rotate_piece(current_piece, grid)
         shape_pos = convert_shape_format(current_piece)
         for j, i in shape_pos:
             if i > -1:
                 grid[i][j] = current_piece.color
         if change_piece:
-            for pos in shape_pos:
-                p = (pos[0], pos[1])
-                locked_positions[p] = current_piece.color
+            score += lock_piece(current_piece, locked_positions)
             current_piece = next_piece
             next_piece = get_shape()
             change_piece = False
-            score += clear_rows(grid, locked_positions) * 10
         draw_window(screen, grid, score)
         draw_next_shape(next_piece, screen)
         pygame.display.update()


### PR DESCRIPTION
## Summary
- extract piece movement, collision and scoring logic into reusable `game_logic.py`
- streamline `tetris.py` to handle rendering and input only
- add unit tests for core gameplay logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d21dea24832da6ed4c74f2267a8c