### PR TITLE
Add web-based Tetris implementation using canvas

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Tetris</title>
+  <style>
+    body { background: #000; color: #fff; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+    canvas { border: 2px solid #fff; }
+  </style>
+</head>
+<body>
+  <canvas id="game" width="300" height="600"></canvas>
+  <script src="tetris.js"></script>
+</body>
+</html>

--- a/web/tetris.js
+++ b/web/tetris.js
@@ -1,0 +1,186 @@
+const COLS = 10;
+const ROWS = 20;
+const BLOCK_SIZE = 30;
+const PLAY_WIDTH = COLS * BLOCK_SIZE;
+const PLAY_HEIGHT = ROWS * BLOCK_SIZE;
+
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+const S = [
+  ['.....','.....','..00.','.00..','.....'],
+  ['.....','..0..','..00.','...0.','.....']
+];
+const Z = [
+  ['.....','.....','.00..','..00.','.....'],
+  ['.....','..0..','.00..','.0...','.....']
+];
+const I = [
+  ['..0..','..0..','..0..','..0..','.....'],
+  ['.....','0000.','.....','.....','.....']
+];
+const O = [
+  ['.....','.....','.00..','.00..','.....']
+];
+const J = [
+  ['.....','.0...','.000.','.....','.....'],
+  ['.....','..00.','..0..','..0..','.....'],
+  ['.....','.....','.000.','...0.','.....'],
+  ['.....','..0..','..0..','.00..','.....']
+];
+const L = [
+  ['.....','...0.','.000.','.....','.....'],
+  ['.....','..0..','..0..','..00.','.....'],
+  ['.....','.....','.000.','.0...','.....'],
+  ['.....','.00..','..0..','..0..','.....']
+];
+const T = [
+  ['.....','..0..','.000.','.....','.....'],
+  ['.....','..0..','..00.','..0..','.....'],
+  ['.....','.....','.000.','..0..','.....'],
+  ['.....','..0..','.00..','..0..','.....']
+];
+
+const SHAPES = [S, Z, I, O, J, L, T];
+const SHAPE_COLORS = ['#00ff00', '#ff0000', '#00ffff', '#ffff00', '#ffa500', '#0000ff', '#800080'];
+
+class Piece {
+  constructor(x, y, shape) {
+    this.x = x;
+    this.y = y;
+    this.shape = shape;
+    this.color = SHAPE_COLORS[SHAPES.indexOf(shape)];
+    this.rotation = 0;
+  }
+}
+
+function createGrid() {
+  return Array.from({ length: ROWS }, () => Array(COLS).fill(0));
+}
+
+function convertShapeFormat(piece) {
+  const positions = [];
+  const format = piece.shape[piece.rotation % piece.shape.length];
+  for (let i = 0; i < format.length; i++) {
+    for (let j = 0; j < format[i].length; j++) {
+      if (format[i][j] === '0') {
+        positions.push({ x: piece.x + j - 2, y: piece.y + i - 4 });
+      }
+    }
+  }
+  return positions;
+}
+
+function validSpace(piece, grid) {
+  const formatted = convertShapeFormat(piece);
+  return formatted.every(p =>
+    p.x >= 0 && p.x < COLS && p.y < ROWS && (p.y < 0 || grid[p.y][p.x] === 0)
+  );
+}
+
+function getShape() {
+  const shape = SHAPES[Math.floor(Math.random() * SHAPES.length)];
+  return new Piece(5, 0, shape);
+}
+
+function clearRows(grid) {
+  let rowsCleared = 0;
+  for (let y = ROWS - 1; y >= 0; y--) {
+    if (grid[y].every(cell => cell !== 0)) {
+      grid.splice(y, 1);
+      grid.unshift(Array(COLS).fill(0));
+      rowsCleared++;
+      y++; // recheck same row
+    }
+  }
+  return rowsCleared;
+}
+
+function drawGrid(grid) {
+  for (let y = 0; y < grid.length; y++) {
+    for (let x = 0; x < grid[y].length; x++) {
+      const cell = grid[y][x];
+      if (cell !== 0) {
+        ctx.fillStyle = cell;
+        ctx.fillRect(x * BLOCK_SIZE, y * BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE);
+      }
+      ctx.strokeStyle = '#222';
+      ctx.strokeRect(x * BLOCK_SIZE, y * BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE);
+    }
+  }
+}
+
+let grid = createGrid();
+let currentPiece = getShape();
+let nextPiece = getShape();
+let dropCounter = 0;
+let dropInterval = 500;
+let lastTime = 0;
+let score = 0;
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawGrid(grid);
+  const positions = convertShapeFormat(currentPiece);
+  positions.forEach(pos => {
+    if (pos.y >= 0) {
+      ctx.fillStyle = currentPiece.color;
+      ctx.fillRect(pos.x * BLOCK_SIZE, pos.y * BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE);
+      ctx.strokeStyle = '#222';
+      ctx.strokeRect(pos.x * BLOCK_SIZE, pos.y * BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE);
+    }
+  });
+  ctx.fillStyle = '#fff';
+  ctx.font = '20px monospace';
+  ctx.fillText('Score: ' + score, 10, 20);
+}
+
+function lockPiece() {
+  const positions = convertShapeFormat(currentPiece);
+  positions.forEach(pos => {
+    if (pos.y >= 0) {
+      grid[pos.y][pos.x] = currentPiece.color;
+    }
+  });
+  score += clearRows(grid) * 10;
+  currentPiece = nextPiece;
+  nextPiece = getShape();
+  if (!validSpace(currentPiece, grid)) {
+    grid = createGrid();
+    score = 0;
+  }
+}
+
+function update(time = 0) {
+  const delta = time - lastTime;
+  lastTime = time;
+  dropCounter += delta;
+  if (dropCounter > dropInterval) {
+    currentPiece.y += 1;
+    if (!validSpace(currentPiece, grid)) {
+      currentPiece.y -= 1;
+      lockPiece();
+    }
+    dropCounter = 0;
+  }
+  draw();
+  requestAnimationFrame(update);
+}
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'ArrowLeft') {
+    currentPiece.x -= 1;
+    if (!validSpace(currentPiece, grid)) currentPiece.x += 1;
+  } else if (e.key === 'ArrowRight') {
+    currentPiece.x += 1;
+    if (!validSpace(currentPiece, grid)) currentPiece.x -= 1;
+  } else if (e.key === 'ArrowDown') {
+    currentPiece.y += 1;
+    if (!validSpace(currentPiece, grid)) currentPiece.y -= 1;
+  } else if (e.key === 'ArrowUp') {
+    currentPiece.rotation += 1;
+    if (!validSpace(currentPiece, grid)) currentPiece.rotation -= 1;
+  }
+});
+
+update();


### PR DESCRIPTION
## Summary
- Add `web/index.html` with canvas for the playfield and script hook
- Implement `web/tetris.js` mirroring Python logic for piece generation, collision checks, scoring, and keyboard controls

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d2196ed4832d86eb253c81b43d27