### PR TITLE
Prevent arrow key scrolling in game

### DIFF
--- a/web/tetris.js
+++ b/web/tetris.js
@@ -216,6 +216,7 @@ function hardDrop() {
 }
 
 document.addEventListener('keydown', e => {
+  e.preventDefault();
   if (e.key === 'ArrowLeft') moveLeft();
   else if (e.key === 'ArrowRight') moveRight();
   else if (e.key === 'ArrowDown') softDrop();


### PR DESCRIPTION
## Summary
- Stop browser page from scrolling when users press arrow keys by preventing default behavior in `keydown` listener.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c66905dfd4832d92392f3f183a35af