### PR TITLE
docs: add PWA install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Tetris
+
+## Install as a PWA (iOS & Android)
+
+- **Android**: tap the address bar menu → **Install App**.
+- **iOS**: Share → **Add to Home Screen** (no auto-prompt).
+- The app must be served over **HTTPS**.
+
+Offline support is available. See [PWA-TEST.md](PWA-TEST.md) for testers.


### PR DESCRIPTION
## Summary
- document installing the Tetris web app as a PWA on Android and iOS
- note requirement for HTTPS and offline support link for testers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c66d53b760832db957a1026dd9fb7e