### PR TITLE
Add PWA install prompt with iOS guard

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -18,6 +18,7 @@
     canvas { background: #000; border: 2px solid #fff; }
     #controls { margin-top: 1em; }
     #controls button { font-size: 1.2em; margin: 0 0.25em; }
+    #install { display: none; font-size: 0.8em; margin-top: 1em; }
   </style>
 </head>
 <body>
@@ -28,6 +29,7 @@
     <button id="right">▶️</button>
     <button id="drop">⏬</button>
   </div>
+  <button id="install">Install</button>
   <script src="tetris.js"></script>
 </body>
 </html>

--- a/web/tetris.js
+++ b/web/tetris.js
@@ -229,11 +229,31 @@ const btnLeft = document.getElementById('left');
 const btnRight = document.getElementById('right');
 const btnRotate = document.getElementById('rotate');
 const btnDrop = document.getElementById('drop');
+const btnInstall = document.getElementById('install');
 
 btnLeft?.addEventListener('click', moveLeft);
 btnRight?.addEventListener('click', moveRight);
 btnRotate?.addEventListener('click', rotate);
 btnDrop?.addEventListener('click', hardDrop);
+
+// Handle PWA installation
+let deferredPrompt;
+const isIOS = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
+if (isIOS) {
+  btnInstall?.remove();
+} else if (btnInstall) {
+  window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+    btnInstall.style.display = 'inline-block';
+  });
+
+  btnInstall.addEventListener('click', () => {
+    btnInstall.style.display = 'none';
+    deferredPrompt.prompt();
+    deferredPrompt = null;
+  });
+}
 
 // Touch gestures on canvas
 let startX = 0, startY = 0;


### PR DESCRIPTION
## Summary
- add hidden Install button to page
- handle `beforeinstallprompt` to show button and trigger installation
- suppress install option on iOS devices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c66d5003b8832d8f013a22eb4455ce