### PR TITLE
Add service worker with cache-first strategy

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -29,5 +29,12 @@
     <button id="drop">⏬</button>
   </div>
   <script src="tetris.js"></script>
+<script>
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js");
+  });
+}
+</script>
 </body>
 </html>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,0 +1,28 @@
+const CACHE = "tetris-v1";
+const ASSETS = [
+  "/", "/index.html", "/tetris.js",
+  "/manifest.webmanifest",
+  "/icons/icon-192.png", "/icons/icon-512.png"
+];
+
+self.addEventListener("install", event => {
+  event.waitUntil(
+    caches.open(CACHE).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener("activate", event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE).map(key => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener("fetch", event => {
+  event.respondWith(
+    caches.match(event.request).then(cached => cached || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- Implement cache-first service worker for offline caching of core assets
- Register service worker on page load to enable offline play

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c66d4d45f4832d929638b2dbbd2d26