### PR TITLE
Remove obsolete on-screen control buttons

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,19 +25,11 @@
       align-items: center;
     }
     canvas { background: #000; border: 2px solid #fff; }
-    #controls { margin-top: 1em; }
-    #controls button { font-size: 1.2em; margin: 0 0.25em; }
     #install { display: none; font-size: 0.8em; margin-top: 1em; }
   </style>
 </head>
 <body class="safe">
   <canvas id="game" width="300" height="600"></canvas>
-  <div id="controls">
-    <button id="left">◀️</button>
-    <button id="rotate">🔄</button>
-    <button id="right">▶️</button>
-    <button id="drop">⏬</button>
-  </div>
   <button id="install">Install</button>
   <script src="tetris.js"></script>
 <script>

--- a/web/tetris.js
+++ b/web/tetris.js
@@ -230,17 +230,7 @@ document.addEventListener('keydown', e => {
   else if (e.key === ' ') hardDrop();
 });
 
-// Hook up on-screen buttons if present
-const btnLeft = document.getElementById('left');
-const btnRight = document.getElementById('right');
-const btnRotate = document.getElementById('rotate');
-const btnDrop = document.getElementById('drop');
 const btnInstall = document.getElementById('install');
-
-btnLeft?.addEventListener('click', moveLeft);
-btnRight?.addEventListener('click', moveRight);
-btnRotate?.addEventListener('click', rotate);
-btnDrop?.addEventListener('click', hardDrop);
 
 // Handle PWA installation
 let deferredPrompt;


### PR DESCRIPTION
## Summary
- remove HTML control buttons and related CSS
- drop JavaScript references to removed buttons, relying on keyboard/touch input

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6d73e54f0832da89d45c93001353a