### PR TITLE
Add HUD and level-based gameplay to web Tetris

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -14,6 +14,10 @@
     html, body { height:100%; margin:0; background:#000; }
     #app, canvas { touch-action:none; }
     .safe { padding-top:env(safe-area-inset-top); padding-bottom:env(safe-area-inset-bottom); }
+    @font-face {
+      font-family: 'Press Start 2P';
+      src: url('https://fonts.gstatic.com/s/pressstart2p/v13/e3t4euK8K0d3wRdoznpThw.woff2') format('woff2');
+    }
     body {
       background: #000;
       color: #fff;
@@ -24,11 +28,24 @@
       justify-content: center;
       align-items: center;
     }
+    #hud {
+      font-family: 'Press Start 2P', monospace;
+      border: 2px solid #fff;
+      padding: 0.5em 1em;
+      margin-bottom: 1em;
+      display: flex;
+      gap: 1em;
+      background: #111;
+    }
     canvas { background: #000; border: 2px solid #fff; }
     #install { display: none; font-size: 0.8em; margin-top: 1em; }
   </style>
 </head>
 <body class="safe">
+  <div id="hud">
+    <div id="score">Score: 0</div>
+    <div id="level">Level: 1</div>
+  </div>
   <canvas id="game" width="300" height="600"></canvas>
   <button id="install">Install</button>
   <script src="tetris.js"></script>

--- a/web/tetris.js
+++ b/web/tetris.js
@@ -4,6 +4,8 @@ const ROWS = 20;
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
+const scoreEl = document.getElementById('score');
+const levelEl = document.getElementById('level');
 
 let BLOCK_SIZE = 30;                 // will be updated on resize
 let PLAY_WIDTH = COLS * BLOCK_SIZE;
@@ -153,9 +155,6 @@ function draw() {
       ctx.strokeRect(pos.x * BLOCK_SIZE, pos.y * BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE);
     }
   });
-  ctx.fillStyle = '#fff';
-  ctx.font = `${Math.floor(BLOCK_SIZE * 0.7)}px monospace`;
-  ctx.fillText('Score: ' + score, 10, Math.floor(BLOCK_SIZE * 0.9));
 }
 
 // ----- Game state -----
@@ -166,19 +165,40 @@ let dropCounter = 0;
 let dropInterval = 500;
 let lastTime = 0;
 let score = 0;
+let level = 1;
+let linesCleared = 0;
+
+function updateHUD() {
+  scoreEl.textContent = 'Score: ' + score;
+  levelEl.textContent = 'Level: ' + level;
+}
+
+updateHUD();
 
 function lockPiece() {
   const positions = convertShapeFormat(currentPiece);
   positions.forEach(pos => {
     if (pos.y >= 0) grid[pos.y][pos.x] = currentPiece.color;
   });
-  score += clearRows(grid) * 10;
+  const cleared = clearRows(grid);
+  if (cleared > 0) {
+    score += cleared * 10;
+    linesCleared += cleared;
+    if (linesCleared >= level * 10) {
+      level++;
+      dropInterval = Math.max(100, 500 - (level - 1) * 50);
+    }
+  }
   currentPiece = nextPiece;
   nextPiece = getShape();
   if (!validSpace(currentPiece, grid)) {
     grid = createGrid();
     score = 0;
+    level = 1;
+    linesCleared = 0;
+    dropInterval = 500;
   }
+  updateHUD();
 }
 
 function update(time = 0) {


### PR DESCRIPTION
## Summary
- Display score and level in a new HUD with retro “Press Start 2P” font
- Track level based on lines cleared and speed up drop interval each level
- Update score and level via DOM instead of drawing text on canvas

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6da416a18832d8d2922d348180b74