### PR TITLE
Allow pieces to enter playfield before collision checks

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -143,7 +143,10 @@ def convert_shape_format(piece: Piece) -> List[Tuple[int, int]]:
 def valid_space(piece: Piece, grid: List[List[Tuple[int, int, int]]]) -> bool:
     accepted_positions = [(j, i) for i in range(GRID_HEIGHT) for j in range(GRID_WIDTH) if grid[i][j] == (0, 0, 0)]
     formatted = convert_shape_format(piece)
-    return all(pos in accepted_positions and pos[1] > -1 for pos in formatted)
+    for x, y in formatted:
+        if (x, y) not in accepted_positions and y > -1:
+            return False
+    return True
 
 
 def move_piece(piece: Piece, dx: int, dy: int, grid: List[List[Tuple[int, int, int]]]) -> bool:

--- a/tetris.py
+++ b/tetris.py
@@ -198,7 +198,10 @@ def convert_shape_format(piece: Piece) -> List[Tuple[int, int]]:
 def valid_space(piece: Piece, grid: List[List[Tuple[int, int, int]]]) -> bool:
     accepted_positions = [(j, i) for i in range(20) for j in range(10) if grid[i][j] == (0, 0, 0)]
     formatted = convert_shape_format(piece)
-    return all(pos in accepted_positions and pos[1] > -1 for pos in formatted)
+    for x, y in formatted:
+        if (x, y) not in accepted_positions and y > -1:
+            return False
+    return True
 
 
 def check_lost(positions: dict) -> bool:


### PR DESCRIPTION
## Summary
- Skip collision checks for blocks above the visible area in `valid_space`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6e2614520832dbd5cb93ae4289193