### PR TITLE
Allow pieces to spawn off-screen in web version

### DIFF
--- a/web/tetris.js
+++ b/web/tetris.js
@@ -105,7 +105,7 @@ function convertShapeFormat(piece) {
 function validSpace(piece, grid) {
   const formatted = convertShapeFormat(piece);
   return formatted.every(p =>
-    p.x >= 0 && p.x < COLS && p.y < ROWS && (p.y < 0 || grid[p.y][p.x] === 0)
+    p.y < 0 || (p.x >= 0 && p.x < COLS && p.y < ROWS && grid[p.y][p.x] === 0)
   );
 }
 


### PR DESCRIPTION
## Summary
- Skip bounds checks for blocks above the board so pieces can spawn off-screen in web Tetris

## Testing
- `pytest tests/test_game_logic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e1741548832d80eb38fd3ad640ea