### PR TITLE
Remove score and level HUD

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -28,24 +28,11 @@
       justify-content: center;
       align-items: center;
     }
-    #hud {
-      font-family: 'Press Start 2P', monospace;
-      border: 2px solid #fff;
-      padding: 0.5em 1em;
-      margin-bottom: 1em;
-      display: flex;
-      gap: 1em;
-      background: #111;
-    }
     canvas { background: #000; border: 2px solid #fff; }
     #install { display: none; font-size: 0.8em; margin-top: 1em; }
   </style>
 </head>
 <body class="safe">
-  <div id="hud">
-    <div id="score">Score: 0</div>
-    <div id="level">Level: 1</div>
-  </div>
   <canvas id="game" width="300" height="600"></canvas>
   <button id="install">Install</button>
   <script src="tetris.js"></script>

--- a/web/tetris.js
+++ b/web/tetris.js
@@ -4,8 +4,6 @@ const ROWS = 20;
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
-const scoreEl = document.getElementById('score');
-const levelEl = document.getElementById('level');
 
 let BLOCK_SIZE = 30;                 // will be updated on resize
 let PLAY_WIDTH = COLS * BLOCK_SIZE;
@@ -178,13 +176,6 @@ let score = 0;
 let level = 1;
 let linesCleared = 0;
 
-function updateHUD() {
-  scoreEl.textContent = 'Score: ' + score;
-  levelEl.textContent = 'Level: ' + level;
-}
-
-updateHUD();
-
 function lockPiece() {
   const positions = convertShapeFormat(currentPiece);
   positions.forEach(pos => {
@@ -208,7 +199,6 @@ function lockPiece() {
     linesCleared = 0;
     dropInterval = 500;
   }
-  updateHUD();
 }
 
 function update(time = 0) {


### PR DESCRIPTION
## Summary
- Remove score and level display container from HTML layout
- Strip out HUD DOM references and update logic from the web Tetris script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ea9cccec832d87809fa81a60ef70