### PR TITLE
Reduce canvas size

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -33,7 +33,7 @@
   </style>
 </head>
 <body class="safe">
-  <canvas id="game" width="300" height="600"></canvas>
+  <canvas id="game" width="150" height="300"></canvas>
   <button id="install">Install</button>
   <script src="tetris.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- Shrink game canvas from 300x600 to 150x300 in web index page
- Canvas remains centered via flexbox layout and smaller grid is computed from 10x20 board

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ef769168832db4e7cc5306919171