### PR TITLE
Fix canvas resize to full viewport

### DIFF
--- a/web/tetris.js
+++ b/web/tetris.js
@@ -18,8 +18,7 @@ function resizeCanvas() {
   const maxH = window.innerHeight - controlsHeight;
 
   // determine block size that fits within viewport
-  const maxPlayableWidth = Math.min(maxW, Math.floor(maxH / 2));
-  BLOCK_SIZE = Math.floor(maxPlayableWidth / COLS / 2);
+  BLOCK_SIZE = Math.floor(Math.min(maxW / COLS, maxH / ROWS));
   PLAY_WIDTH = COLS * BLOCK_SIZE;
   PLAY_HEIGHT = ROWS * BLOCK_SIZE;
 


### PR DESCRIPTION
## Summary
- Simplify block size calculation using viewport dimensions to ensure full-width canvas
- Recompute playfield dimensions based on updated block size

## Testing
- `node <<'NODE' ...` (simulate resize logic)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f25be680832db978742b64cb623f